### PR TITLE
fix: subscan link in timeline no-show issue

### DIFF
--- a/packages/next/components/timeline/links.js
+++ b/packages/next/components/timeline/links.js
@@ -47,7 +47,7 @@ export default function Links({
   style = {},
   address,
 }) {
-  if (!address) {
+  if (!indexer && !address) {
     return null;
   }
   if (chain === "karura") {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/12393771/133880168-1066e619-2691-4762-a7f0-af74c83281c1.png)
