### PR TITLE
fix: use a height_hash to locate financial motion instead of motionIn…

### DIFF
--- a/packages/next/utils/viewfuncs.js
+++ b/packages/next/utils/viewfuncs.js
@@ -52,7 +52,7 @@ export const toFinancialMotionsListItem = (chain, item) => ({
     addresses: [{ chain, address: item.proposer }],
   },
   status: item.state ?? "Unknown",
-  detailLink: `/financial-council/motion/${item.motionIndex}`,
+  detailLink: `/financial-council/motion/${item.indexer.blockHeight}_${item.hash}`,
   time: getPostUpdatedAt(item),
 });
 


### PR DESCRIPTION
…dex(which is not unique) #943