### PR TITLE
improve: numbers in democracy summary will be 0 by default

### DIFF
--- a/packages/next-common/components/summary/democracySummary.js
+++ b/packages/next-common/components/summary/democracySummary.js
@@ -124,8 +124,8 @@ export default function DemocracySummary({ chain }) {
         <Title>Proposals</Title>
         <Content>
           <span>
-            {summary.activeProposalsCount}
-            <GreyText> / {summary.publicPropCount}</GreyText>
+            {summary.activeProposalsCount || 0}
+            <GreyText> / {summary.publicPropCount || 0}</GreyText>
           </span>
         </Content>
       </Card>
@@ -133,8 +133,8 @@ export default function DemocracySummary({ chain }) {
         <Title>Referenda</Title>
         <Content>
           <span>
-            {summary.referendumCount}
-            <GreyText> / {summary.referendumTotal}</GreyText>
+            {summary.referendumCount || 0}
+            <GreyText> / {summary.referendumTotal || 0}</GreyText>
           </span>
         </Content>
       </Card>


### PR DESCRIPTION
# While loading
![image](https://user-images.githubusercontent.com/12393771/153418730-4096f82f-9c2e-486c-a260-f92911110c3d.png)
# Loaded
![image](https://user-images.githubusercontent.com/12393771/153418756-1593f90e-1e38-4382-a247-2ae6756b7e3e.png)
