### PR TITLE
fix regex expecetion for safari (also firefox)

### DIFF
--- a/packages/next-common/utils/index.js
+++ b/packages/next-common/utils/index.js
@@ -169,7 +169,7 @@ export function bigNumber2Locale(x) {
 
 export function matchMdLink(t) {
   const expression =
-    /(?<!\]\()((?:https?|ftp):\/\/[^\s\]\)]*)(?:[\s\]\)](?!\()|$)/gi;
+    /(?!]\()((?:https?|ftp):\/\/[^\s\])]*)(?:[\s\])](?!\()|$)/gi;
   return t.replace(expression, "[$1]($1) ");
 }
 


### PR DESCRIPTION
<img width="1011" alt="image" src="https://user-images.githubusercontent.com/12393771/168531586-7bce1c9e-e019-4d28-bfe1-b7e5880b29c9.png">
refs #1050 