### PR TITLE
hotfix: markdown inline code css

### DIFF
--- a/packages/next-common/components/micromarkMd.js
+++ b/packages/next-common/components/micromarkMd.js
@@ -115,13 +115,13 @@ const Wrapper = styled.div`
         Liberation Mono, monospace !important;
       ${no_scroll_bar};
       max-width: 100%;
-      margin: 16px 0;
       padding: 0 0.25rem;
       background: #f5f8fa !important;
       border-radius: 0.25rem;
       white-space: nowrap !important;
       word-break: keep-all;
       overflow-x: scroll;
+      display: inline-flex;
     }
 
     a {


### PR DESCRIPTION
inline code, it is previous behaviour

![0qkh5FXjE8](https://user-images.githubusercontent.com/19513289/172571316-661d0dd1-f063-471f-b907-edba10fe4909.jpg)
