### PR TITLE
fix: page post poll option title break word

### DIFF
--- a/packages/next-common/components/poll/options.js
+++ b/packages/next-common/components/poll/options.js
@@ -37,6 +37,7 @@ const Title = styled.div`
   font-weight: 500;
   font-size: 14px;
   line-height: 100%;
+  word-break: break-word;
 `;
 
 const StatsNumbers = styled.div`


### PR DESCRIPTION
<img width="773" alt="image" src="https://user-images.githubusercontent.com/19513289/174738294-035168b8-6534-44eb-b2cd-03f8a8ba7605.png">