### PR TITLE
fix: gov2 detail sidebar inline elements(button, learn gov2 link)

### DIFF
--- a/packages/next-common/components/detail/sidebar/styled.js
+++ b/packages/next-common/components/detail/sidebar/styled.js
@@ -16,3 +16,10 @@ const Link = styled(ExternalLink)`
 `;
 
 export { Link };
+
+export const InlineWrapper = styled.div`
+  ${mdcss(css`
+    padding-left: 16px;
+    padding-right: 16px;
+  `)}
+`;


### PR DESCRIPTION
close #2526 