### PR TITLE
fix: menu import

### DIFF
--- a/packages/next/components/settings/subscription/useAdvisoryCommitteeSubscription.js
+++ b/packages/next/components/settings/subscription/useAdvisoryCommitteeSubscription.js
@@ -1,4 +1,4 @@
-import homeMenus from "next-common/utils/consts/menu";
+import { getHomeMenu } from "next-common/utils/consts/menu";
 import useAdvisoryCommitteeOptions from "next-common/components/setting/notification/useAdvisoryCommitteeOptions";
 import { checkSubMenu } from "./common";
 import FoldableSections from "next-common/components/setting/notification/foldableSections";
@@ -8,6 +8,8 @@ export default function useAdvisoryCommitteeSubscription(
   saving,
   isVerifiedUser
 ) {
+  const homeMenus = getHomeMenu();
+
   const { hasMenu: hasAdvisoryCommittee } = checkSubMenu(
     homeMenus,
     "ADVISORY COMMITTEE"

--- a/packages/next/components/settings/subscription/useCouncilSubscription.js
+++ b/packages/next/components/settings/subscription/useCouncilSubscription.js
@@ -1,4 +1,4 @@
-import homeMenus from "next-common/utils/consts/menu";
+import { getHomeMenu } from "next-common/utils/consts/menu";
 import { checkSubMenu } from "./common";
 import FoldableSections from "next-common/components/setting/notification/foldableSections";
 import useCouncilMotionOptions from "next-common/components/setting/notification/useCouncilMotionOptions";
@@ -8,6 +8,8 @@ export default function useCouncilSubscription(
   saving,
   isVerifiedUser
 ) {
+  const homeMenus = getHomeMenu();
+
   const { hasMenu: hasCouncil, menu: councilMenu } = checkSubMenu(
     homeMenus,
     "COUNCIL"

--- a/packages/next/components/settings/subscription/useDemocracySubscription.js
+++ b/packages/next/components/settings/subscription/useDemocracySubscription.js
@@ -1,4 +1,4 @@
-import homeMenus from "next-common/utils/consts/menu";
+import { getHomeMenu } from "next-common/utils/consts/menu";
 import { checkSubMenu } from "./common";
 import FoldableSections from "next-common/components/setting/notification/foldableSections";
 import useDemocracyProposalOptions from "next-common/components/setting/notification/useDemocracyProposalOptions";
@@ -9,6 +9,8 @@ export default function useDemocracySubscription(
   saving,
   isVerifiedUser
 ) {
+  const homeMenus = getHomeMenu();
+
   const { hasMenu: hasDemocracy, menu: democracyMenu } = checkSubMenu(
     homeMenus,
     "DEMOCRACY"

--- a/packages/next/components/settings/subscription/useTechCommSubscription.js
+++ b/packages/next/components/settings/subscription/useTechCommSubscription.js
@@ -1,4 +1,4 @@
-import homeMenus from "next-common/utils/consts/menu";
+import { getHomeMenu } from "next-common/utils/consts/menu";
 import { checkSubMenu } from "./common";
 import FoldableSections from "next-common/components/setting/notification/foldableSections";
 import useTechCommMotionOptions from "next-common/components/setting/notification/useTechCommMotionOptions";
@@ -8,6 +8,8 @@ export default function useTechCommSubscription(
   saving,
   isVerifiedUser
 ) {
+  const homeMenus = getHomeMenu();
+
   const { hasMenu: hasTechComm, menu: techCommMenu } = checkSubMenu(
     homeMenus,
     "TECH.COMM."

--- a/packages/next/components/settings/subscription/useTreasurySubscription.js
+++ b/packages/next/components/settings/subscription/useTreasurySubscription.js
@@ -1,4 +1,4 @@
-import homeMenus from "next-common/utils/consts/menu";
+import { getHomeMenu } from "next-common/utils/consts/menu";
 import { checkSubMenu } from "./common";
 import FoldableSections from "next-common/components/setting/notification/foldableSections";
 import useTreasuryChildBountyOptions from "next-common/components/setting/notification/useTreasuryChildBountyOptions";
@@ -11,6 +11,8 @@ export default function useTreasrySubscription(
   saving,
   isVerifiedUser
 ) {
+  const homeMenus = getHomeMenu();
+
   const { hasMenu: hasTreasury, menu: treasuryMenu } = checkSubMenu(
     homeMenus,
     "TREASURY"


### PR DESCRIPTION
```console
info  - Linting and checking validity of types
info  - Disabled SWC as replacement for Babel because of custom Babel configuration "babel.config.js" https://nextjs.o
rg/docs/messages/swc-disabled
info  - Using external babel configuration from /Users/2nthony/ghq/github.com/opensquare-network/subsquare/packages/ne
xt/babel.config.js
info  - Creating an optimized production build
info  - Compiled successfully
info  - Collecting page data
info  - Generating static pages (3/3)
info  - Finalizing page optimization

Route (pages)                              Size     First Load JS
┌ λ /                                      9.52 kB        1.17 MB
```