### PR TITLE
hotfix: cell remark markdown text color

### DIFF
--- a/packages/next-common/components/common/call/remarks.js
+++ b/packages/next-common/components/common/call/remarks.js
@@ -6,6 +6,7 @@ import styled from "styled-components";
 
 const RemarkWrapper = styled.div`
   .markdown-body {
+    color: inherit;
     word-break: break-word;
   }
 `;


### PR DESCRIPTION
inherit

@wliyongfeng 