### PR TITLE
Typo: mange -> manage

### DIFF
--- a/packages/next/pages/democracy/externals/index.js
+++ b/packages/next/pages/democracy/externals/index.js
@@ -19,7 +19,7 @@ export default function DemocracyExternalsPage({ externals, chain, summary }) {
     <ListLayout
       seoInfo={seoInfo}
       title={category}
-      description="Democracy uses public proposal, external proposal and referenda to mange the governance process."
+      description="Democracy uses public proposal, external proposal and referenda to manage the governance process."
       summary={<DemocracySummary summary={summary} />}
     >
       <PostList

--- a/packages/next/pages/democracy/proposals/index.js
+++ b/packages/next/pages/democracy/proposals/index.js
@@ -27,7 +27,7 @@ export default function DemocracyProposalsPage({ proposals, summary }) {
     <ListLayout
       seoInfo={seoInfo}
       title={category}
-      description="Democracy uses public proposal, external proposal and referenda to mange the governance process."
+      description="Democracy uses public proposal, external proposal and referenda to manage the governance process."
       summary={<DemocracySummary summary={summary} />}
     >
       <PostList


### PR DESCRIPTION
This PR fixes a simple typo in two pages.