### PR TITLE
Fix: Ensure PolkaGate Snap Remains Enabled in useInjectedWeb3 Hook

### DIFF
--- a/packages/next-common/components/wallet/useInjectedWeb3.js
+++ b/packages/next-common/components/wallet/useInjectedWeb3.js
@@ -14,7 +14,8 @@ export default function useInjectedWeb3() {
 
     if (isMounted()) {
       if (typeof window !== "undefined") {
-        if (window.injectedWeb3) {
+        // Added for supporting PolkaGate Snap, when no wallets are available!
+        if (window.injectedWeb3 || window.ethereum?.isMetaMask) {
           handleWeb3();
         }
       } else {
@@ -23,7 +24,7 @@ export default function useInjectedWeb3() {
         }, 1000);
       }
     }
-  }, [isMounted]);
+  }, [isMounted, window?.injectedWeb3]);
 
   return { loading, injectedWeb3 };
 }


### PR DESCRIPTION
## Summary
This pull request addresses the issue where PolkaGate Snap on MetaMask becomes disabled when only MetaMask is available on the browser.

## Changes
- Modified `useInjectedWeb3` hook to include a check for `window.ethereum?.isMetaMask`.
- Added comments to explain the additional check for PolkaGate Snap.

## Related Issue
Fixes [issue #4399](https://github.com/opensquare-network/subsquare/issues/4399).

## Verification
Tested in an environment with MetaMask and no other web3 wallets on the browser. The hook now correctly handles PolkaGate Snap.