### PR TITLE
minor-grammatical-typo

### DIFF
--- a/packages/next/components/myvotes/vote/lock.js
+++ b/packages/next/components/myvotes/vote/lock.js
@@ -41,8 +41,8 @@ function LockCountDown({ lockInfo }) {
     return <LockExpired lockEnd={lockEnd} />;
   }
 
-  const shortText = `Lock expired in ${estimatedBlocksTime}`;
-  const tooltip = `Expired at ${lockEnd}, blocks remaining ${
+  const shortText = `Lock expires in ${estimatedBlocksTime}`;
+  const tooltip = `Expires at ${lockEnd}, blocks remaining ${
     lockEnd - blockHeight
   }`;
   return (


### PR DESCRIPTION
Whenever a lock happens the text writes in past tense ("Expired") while it still in pending state to expire. It needs to alter to different tense.