### PR TITLE
fix: popup close behaviour #5138

### DIFF
--- a/packages/next-common/components/popup/wrapper/Popup.js
+++ b/packages/next-common/components/popup/wrapper/Popup.js
@@ -27,14 +27,7 @@ export default function Popup({
 
   return (
     <CommonPopupProvider onClose={onClose}>
-      <Dialog.Root
-        open
-        onOpenChange={() => {
-          if (maskClosable) {
-            onClose();
-          }
-        }}
-      >
+      <Dialog.Root open>
         <Dialog.Portal container={container}>
           <Dialog.Overlay />
           <Dialog.Content asChild onOpenAutoFocus={(e) => e.preventDefault()}>


### PR DESCRIPTION
clicking `toast/other elements` should not close popup