### PR TITLE
fix: collectives, page cycle detail crashed

### DIFF
--- a/packages/next-common/components/fellowship/salary/actions/bump/index.js
+++ b/packages/next-common/components/fellowship/salary/actions/bump/index.js
@@ -18,7 +18,7 @@ export default function FellowshipSalaryBump() {
   const [showPopup, setShowPopup] = useState(false);
   const address = useRealAddress();
 
-  const { cycleStart } = useFellowshipSalaryStats();
+  const { cycleStart } = useFellowshipSalaryStats() || {};
   const { registrationPeriod, payoutPeriod } = useSalaryFellowshipPeriods();
   const nextCycleStart =
     cycleStart + (registrationPeriod || null) + (payoutPeriod || null);


### PR DESCRIPTION
`useFellowshipSalaryStats` add fallback value