### PR TITLE
Fix wording for "unvoted" section

### DIFF
--- a/packages/next/components/fellowship/referendum/sidebar/tally/eligibleVoters/unVoted.jsx
+++ b/packages/next/components/fellowship/referendum/sidebar/tally/eligibleVoters/unVoted.jsx
@@ -17,7 +17,7 @@ export default function UnVoted({ unVotedMembers, isLoading }) {
     <div>
       <TitleContainer className="text14Bold px-0 pb-3">
         <span>
-          Un-voted
+          Not yet voted
           <span className="text-textTertiary text14Medium ml-1">
             {!isLoading && total}
           </span>


### PR DESCRIPTION
This is a nice addition to the platform, but I think the wording is a bit misleading.

I've changed it to better reflect what it shows - people who are eligible to vote but who have not yet voted.