### PR TITLE
hotfix: number input format

### DIFF
--- a/packages/next-common/lib/input/number/utils.js
+++ b/packages/next-common/lib/input/number/utils.js
@@ -32,7 +32,7 @@ function formatValue(value = "") {
     value = "0" + value;
   }
 
-  const formatter = new Intl.NumberFormat(undefined, {
+  const formatter = new Intl.NumberFormat("en-US", {
     minimumFractionDigits: 0,
     maximumFractionDigits: 20,
   });


### PR DESCRIPTION
forced to `en-US`

close #5437 