### PR TITLE
Use components instead of hooks to refactor account panel prompts, #6573

### DIFF
--- a/packages/next-common/components/overview/accountInfo/accountInfoPanel.js
+++ b/packages/next-common/components/overview/accountInfo/accountInfoPanel.js
@@ -26,8 +26,6 @@ import { isNil } from "lodash-es";
 import Link from "next/link";
 import Button from "next-common/lib/button";
 import AccountPanelQuickAccess from "./components/accountPanelQuickAccess";
-import AccountUnlockBalancePrompt from "./components/accountUnlockBalancePrompt";
-import WithPallet from "next-common/components/common/withPallet";
 import useRealAddress from "next-common/utils/hooks/useRealAddress";
 import Avatar from "next-common/components/avatar";
 import getIpfsLink from "next-common/utils/env/ipfsEndpoint";
@@ -309,9 +307,6 @@ export default function AccountInfoPanel() {
       <Divider />
       <AccountBalances />
       <ExtensionUpdatePrompt />
-      <WithPallet pallet="referenda">
-        <AccountUnlockBalancePrompt />
-      </WithPallet>
       <AccountPanelScrollPrompt />
     </NeutralPanel>
   );

--- a/packages/next-common/components/overview/accountInfo/components/accountPanelScrollPrompt.js
+++ b/packages/next-common/components/overview/accountInfo/components/accountPanelScrollPrompt.js
@@ -1,53 +1,20 @@
-import { useEffect, useState } from "react";
-import useDelegationPrompt from "./useDelegationPrompt";
-import useSetAvatarPrompt from "./useSetAvatarPrompt";
-import { isEmpty } from "lodash-es";
-import ScrollPrompt from "next-common/components/scrollPrompt";
-import useSetIdentityPrompt from "./useSetIdentityPrompt";
-import useMultisigPrompt from "./useMultisigPrompt";
-import useAssetHubManagePrompt from "./useAssetHubManagePrompt";
-import { AssetHubMetadataProvider } from "../context/assetHubMetadataContext";
+import { DelegationPrompt } from "./useDelegationPrompt";
+import { AvatarPrompt } from "./useSetAvatarPrompt";
+import { AccountPanelScroll } from "next-common/components/scrollPrompt";
+import { IdentityPrompt } from "./useSetIdentityPrompt";
+import { MultisigPrompt } from "./useMultisigPrompt";
+import AssetHubManagePrompt from "./useAssetHubManagePrompt";
 
 export default function AccountPanelScrollPrompt() {
   return (
-    <AssetHubMetadataProvider>
-      <AccountPanelScrollPromptImpl />
-    </AssetHubMetadataProvider>
-  );
-}
-
-function AccountPanelScrollPromptImpl() {
-  const delegationPrompt = useDelegationPrompt();
-  const setAvatarPrompt = useSetAvatarPrompt();
-  const setIdentityPrompt = useSetIdentityPrompt();
-  const multisigPrompt = useMultisigPrompt();
-  const assetHubManagePrompt = useAssetHubManagePrompt();
-
-  const [prompts, setPrompts] = useState([]);
-
-  useEffect(() => {
-    setPrompts(
-      [
-        multisigPrompt,
-        delegationPrompt,
-        setAvatarPrompt,
-        setIdentityPrompt,
-        assetHubManagePrompt,
-      ].filter((item) => !isEmpty(item)),
-    );
-  }, [
-    assetHubManagePrompt,
-    delegationPrompt,
-    multisigPrompt,
-    setAvatarPrompt,
-    setIdentityPrompt,
-  ]);
-
-  return (
-    <ScrollPrompt
-      prompts={prompts}
-      setPrompts={setPrompts}
-      pageSize={prompts.length > 2 ? 2 : 1}
+    <AccountPanelScroll
+      items={[
+        DelegationPrompt,
+        AvatarPrompt,
+        IdentityPrompt,
+        MultisigPrompt,
+        AssetHubManagePrompt,
+      ]}
     />
   );
 }

--- a/packages/next-common/components/overview/accountInfo/components/accountPanelScrollPrompt.js
+++ b/packages/next-common/components/overview/accountInfo/components/accountPanelScrollPrompt.js
@@ -72,12 +72,12 @@ export default function AccountPanelScrollPrompt() {
       }
       const scrollTop = wrapperRef.current?.scrollTop;
 
-      animate(0, 100, {
+      animate(scrollTop, scrollTop + marginTop, {
         duration: 1,
         times: [0, 1],
-        onUpdate: (v) => {
+        onUpdate: (top) => {
           wrapperRef.current?.scrollTo({
-            top: (v / 100) * marginTop + scrollTop,
+            top: top,
           });
         },
       });

--- a/packages/next-common/components/overview/accountInfo/components/accountPanelScrollPrompt.js
+++ b/packages/next-common/components/overview/accountInfo/components/accountPanelScrollPrompt.js
@@ -7,6 +7,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { animate } from "framer-motion";
 import { useWindowSize } from "react-use";
 import { Fragment } from "react";
+import AccountUnlockBalancePrompt from "./accountUnlockBalancePrompt";
 
 const ITEM_HEIGHT = 40;
 const MOBILE_ITEM_HEIGHT = 60;
@@ -18,6 +19,7 @@ const promptComponents = [
   IdentityPrompt,
   MultisigPrompt,
   AssetHubManagePrompt,
+  AccountUnlockBalancePrompt,
 ];
 
 export default function AccountPanelScrollPrompt() {
@@ -46,9 +48,9 @@ export default function AccountPanelScrollPrompt() {
 
   const marginTop = useMemo(() => {
     if (isMobile) {
-      return (MOBILE_ITEM_HEIGHT + ITEM_GAP) * 1;
+      return MOBILE_ITEM_HEIGHT + ITEM_GAP;
     }
-    return (ITEM_HEIGHT + ITEM_GAP) * 1;
+    return ITEM_HEIGHT + ITEM_GAP;
   }, [isMobile]);
 
   const indexRef = useRef(0);

--- a/packages/next-common/components/overview/accountInfo/components/accountPanelScrollPrompt.js
+++ b/packages/next-common/components/overview/accountInfo/components/accountPanelScrollPrompt.js
@@ -1,20 +1,113 @@
 import { DelegationPrompt } from "./useDelegationPrompt";
 import { AvatarPrompt } from "./useSetAvatarPrompt";
-import { AccountPanelScroll } from "next-common/components/scrollPrompt";
 import { IdentityPrompt } from "./useSetIdentityPrompt";
 import { MultisigPrompt } from "./useMultisigPrompt";
 import AssetHubManagePrompt from "./useAssetHubManagePrompt";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { animate } from "framer-motion";
+import { useWindowSize } from "react-use";
+import { Fragment } from "react";
+
+const ITEM_HEIGHT = 40;
+const MOBILE_ITEM_HEIGHT = 60;
+const ITEM_GAP = 4;
+
+const promptComponents = [
+  DelegationPrompt,
+  AvatarPrompt,
+  IdentityPrompt,
+  MultisigPrompt,
+  AssetHubManagePrompt,
+];
 
 export default function AccountPanelScrollPrompt() {
+  const wrapperRef = useRef();
+  const { width } = useWindowSize();
+  const isMobile = width < 768;
+  const [total, setTotal] = useState(0);
+  const pauseRef = useRef(false);
+
+  const pageSize = total > 2 ? 2 : 1;
+
+  const wrapperHeight = useMemo(() => {
+    if (!total) {
+      return 0;
+    }
+    if (isMobile) {
+      return pageSize * MOBILE_ITEM_HEIGHT + ITEM_GAP * (pageSize - 1);
+    }
+    return pageSize * ITEM_HEIGHT + ITEM_GAP * (pageSize - 1);
+  }, [isMobile, pageSize, total]);
+
+  const [random, setRandom] = useState(1);
+  useEffect(() => {
+    setTotal(wrapperRef.current.children.length / 2);
+  }, [random]);
+
+  const marginTop = useMemo(() => {
+    if (isMobile) {
+      return (MOBILE_ITEM_HEIGHT + ITEM_GAP) * 1;
+    }
+    return (ITEM_HEIGHT + ITEM_GAP) * 1;
+  }, [isMobile]);
+
+  const indexRef = useRef(0);
+
+  useEffect(() => {
+    if (total < 2) {
+      return;
+    }
+
+    const interval = setInterval(() => {
+      if (pauseRef.current || !wrapperRef.current) {
+        return;
+      }
+      if (indexRef.current > total) {
+        wrapperRef.current?.scrollTo({
+          top: 0,
+        });
+        indexRef.current = 1;
+      }
+      const scrollTop = wrapperRef.current?.scrollTop;
+
+      animate(0, 100, {
+        duration: 1,
+        times: [0, 1],
+        onUpdate: (v) => {
+          wrapperRef.current?.scrollTo({
+            top: (v / 100) * marginTop + scrollTop,
+          });
+        },
+      });
+
+      indexRef.current++;
+    }, 6500);
+    return () => clearInterval(interval);
+  }, [marginTop, total]);
+
   return (
-    <AccountPanelScroll
-      items={[
-        DelegationPrompt,
-        AvatarPrompt,
-        IdentityPrompt,
-        MultisigPrompt,
-        AssetHubManagePrompt,
-      ]}
-    />
+    <div
+      ref={wrapperRef}
+      style={{
+        height: wrapperHeight + "px",
+        display: total ? "" : "none",
+      }}
+      className=" overflow-y-hidden flex flex-col gap-1"
+      onMouseEnter={() => (pauseRef.current = true)}
+      onMouseLeave={() => (pauseRef.current = false)}
+    >
+      {[...promptComponents, ...promptComponents].map((Item, index) => {
+        return (
+          <Fragment key={index}>
+            <Item
+              key={random}
+              onClose={() => {
+                setRandom(random + 1);
+              }}
+            />
+          </Fragment>
+        );
+      })}
+    </div>
   );
 }

--- a/packages/next-common/components/overview/accountInfo/components/useDelegationPrompt.js
+++ b/packages/next-common/components/overview/accountInfo/components/useDelegationPrompt.js
@@ -1,4 +1,8 @@
-import { PromptTypes } from "next-common/components/scrollPrompt";
+import { isEmpty } from "lodash-es";
+import {
+  PromptTypes,
+  ScrollPromptItemWrapper,
+} from "next-common/components/scrollPrompt";
 import { useChain, useChainSettings } from "next-common/context/chain";
 import { isKintsugiChain } from "next-common/utils/chain";
 import { CACHE_KEY } from "next-common/utils/constants";
@@ -39,4 +43,23 @@ export default function useDelegationPrompt() {
       close: () => setVisible(false, { expires: 15 }),
     };
   }, [setVisible, hasDelegation, visible]);
+}
+
+export function DelegationPrompt({ onClose }) {
+  const prompt = useDelegationPrompt();
+  if (isEmpty(prompt)) {
+    return null;
+  }
+
+  return (
+    <ScrollPromptItemWrapper
+      prompt={{
+        ...prompt,
+        close: () => {
+          onClose?.();
+          prompt?.close();
+        },
+      }}
+    />
+  );
 }

--- a/packages/next-common/components/overview/accountInfo/components/useMultisigPrompt.jsx
+++ b/packages/next-common/components/overview/accountInfo/components/useMultisigPrompt.jsx
@@ -1,4 +1,7 @@
-import { PromptTypes } from "next-common/components/scrollPrompt";
+import {
+  PromptTypes,
+  ScrollPromptItemWrapper,
+} from "next-common/components/scrollPrompt";
 import { CACHE_KEY } from "next-common/utils/constants";
 import { useCookieValue } from "next-common/utils/hooks/useCookieValue";
 import Link from "next/link";
@@ -8,6 +11,7 @@ import useExplorerMultisigHistory from "next-common/hooks/multisig/useExplorerMu
 import useMultisigAccount from "next-common/hooks/multisig/useMultisigAccount";
 import { useChain } from "next-common/context/chain";
 import { useRouter } from "next/router";
+import { isEmpty } from "lodash-es";
 
 export default function useMultisigPrompt() {
   const [visible, setVisible] = useCookieValue(
@@ -53,4 +57,22 @@ export default function useMultisigPrompt() {
     setVisible,
     visible,
   ]);
+}
+
+export function MultisigPrompt({ onClose }) {
+  const prompt = useMultisigPrompt();
+  if (isEmpty(prompt)) {
+    return null;
+  }
+  return (
+    <ScrollPromptItemWrapper
+      prompt={{
+        ...prompt,
+        close: () => {
+          onClose?.();
+          prompt?.close();
+        },
+      }}
+    />
+  );
 }

--- a/packages/next-common/components/overview/accountInfo/components/useSetAvatarPrompt.js
+++ b/packages/next-common/components/overview/accountInfo/components/useSetAvatarPrompt.js
@@ -1,4 +1,8 @@
-import { PromptTypes } from "next-common/components/scrollPrompt";
+import { isEmpty } from "lodash-es";
+import {
+  PromptTypes,
+  ScrollPromptItemWrapper,
+} from "next-common/components/scrollPrompt";
 import { useIsWeb3User, useUser } from "next-common/context/user";
 import { CACHE_KEY } from "next-common/utils/constants";
 import { useCookieValue } from "next-common/utils/hooks/useCookieValue";
@@ -33,4 +37,23 @@ export default function useSetAvatarPrompt() {
       close: () => setVisible(false, { expires: 15 }),
     };
   }, [setVisible, isWeb3User, visible, hasAvatar]);
+}
+
+export function AvatarPrompt({ onClose }) {
+  const prompt = useSetAvatarPrompt();
+  if (isEmpty(prompt)) {
+    return null;
+  }
+
+  return (
+    <ScrollPromptItemWrapper
+      prompt={{
+        ...prompt,
+        close: () => {
+          onClose?.();
+          prompt?.close();
+        },
+      }}
+    />
+  );
 }

--- a/packages/next-common/components/overview/accountInfo/components/useSetIdentityPrompt.js
+++ b/packages/next-common/components/overview/accountInfo/components/useSetIdentityPrompt.js
@@ -1,5 +1,8 @@
 import Link from "next/link";
-import { PromptTypes } from "next-common/components/scrollPrompt";
+import {
+  PromptTypes,
+  ScrollPromptItemWrapper,
+} from "next-common/components/scrollPrompt";
 import { CACHE_KEY } from "next-common/utils/constants";
 import { useCookieValue } from "next-common/utils/hooks/useCookieValue";
 import { useMemo } from "react";
@@ -7,6 +10,7 @@ import { useChainSettings } from "next-common/context/chain";
 import { useRouter } from "next/router";
 import useIdentityInfo from "next-common/hooks/useIdentityInfo";
 import useRealAddress from "next-common/utils/hooks/useRealAddress";
+import { isEmpty } from "lodash-es";
 
 const identityPage = "/people";
 const judgementPage = "/people?tab=judgements";
@@ -85,4 +89,21 @@ export default function useSetIdentityPrompt() {
     supportedPeople,
     visible,
   ]);
+}
+export function IdentityPrompt({ onClose }) {
+  const prompt = useSetIdentityPrompt();
+  if (isEmpty(prompt)) {
+    return null;
+  }
+  return (
+    <ScrollPromptItemWrapper
+      prompt={{
+        ...prompt,
+        close: () => {
+          onClose?.();
+          prompt?.close();
+        },
+      }}
+    />
+  );
 }

--- a/packages/next-common/components/scrollPrompt/index.js
+++ b/packages/next-common/components/scrollPrompt/index.js
@@ -1,8 +1,9 @@
 import { SystemClose } from "@osn/icons/subsquare";
 import { cn } from "next-common/utils";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useAnimate } from "framer-motion";
+import { animate, useAnimate } from "framer-motion";
 import { useWindowSize } from "react-use";
+import { Fragment } from "react";
 
 export const PromptTypes = {
   INFO: "info",
@@ -151,6 +152,121 @@ export default function ScrollPrompt({
           );
         })}
       </div>
+    </div>
+  );
+}
+
+export function ScrollPromptItemWrapper({ prompt }) {
+  const { width } = useWindowSize();
+  const isMobile = width < 768;
+  return (
+    <div
+      key={prompt.key}
+      className={cn(
+        "flex justify-between items-center rounded-lg",
+        "text14Medium py-2.5 px-4 flex-shrink-0",
+        isMobile ? "h-[60px]" : "h-[40px]",
+      )}
+      style={colorStyle[prompt.type || PromptTypes.NEUTRAL]}
+    >
+      <div>{prompt.message}</div>
+      <SystemClose
+        className="w-5 h-5 flex-shrink-0"
+        role="button"
+        onClick={prompt.close}
+      />
+    </div>
+  );
+}
+
+export function AccountPanelScroll({ items }) {
+  const wrapperRef = useRef();
+  const { width } = useWindowSize();
+  const isMobile = width < 768;
+  const [total, setTotal] = useState(0);
+  const pauseRef = useRef(false);
+
+  const pageSize = total > 2 ? 2 : 1;
+
+  const wrapperHeight = useMemo(() => {
+    if (!total) {
+      return 0;
+    }
+    if (isMobile) {
+      return pageSize * MOBILE_ITEM_HEIGHT + ITEM_GAP * (pageSize - 1);
+    }
+    return pageSize * ITEM_HEIGHT + ITEM_GAP * (pageSize - 1);
+  }, [isMobile, pageSize, total]);
+
+  const [random, setRandom] = useState(1);
+  useEffect(() => {
+    setTotal(wrapperRef.current.children.length / 2);
+  }, [random]);
+
+  const marginTop = useMemo(() => {
+    if (isMobile) {
+      return (MOBILE_ITEM_HEIGHT + ITEM_GAP) * 1;
+    }
+    return (ITEM_HEIGHT + ITEM_GAP) * 1;
+  }, [isMobile]);
+
+  const indexRef = useRef(0);
+
+  useEffect(() => {
+    if (total < 2) {
+      return;
+    }
+
+    const interval = setInterval(() => {
+      if (pauseRef.current || !wrapperRef.current) {
+        return;
+      }
+      if (indexRef.current > total) {
+        wrapperRef.current?.scrollTo({
+          top: 0,
+        });
+        indexRef.current = 1;
+      }
+      const scrollTop = wrapperRef.current?.scrollTop;
+
+      animate(0, 100, {
+        duration: 1,
+        times: [0, 1],
+        onUpdate: (v) => {
+          wrapperRef.current?.scrollTo({
+            top: (v / 100) * marginTop + scrollTop,
+          });
+        },
+      });
+
+      indexRef.current++;
+    }, 6500);
+    return () => clearInterval(interval);
+  }, [marginTop, total]);
+
+  return (
+    <div
+      ref={wrapperRef}
+      style={{
+        height: wrapperHeight + "px",
+        display: total ? "" : "none",
+      }}
+      className=" overflow-y-hidden flex flex-col gap-1"
+      onMouseEnter={() => (pauseRef.current = true)}
+      onMouseLeave={() => (pauseRef.current = false)}
+    >
+      {[...items, ...items].map((Item, index) => {
+        return (
+          <Fragment key={index}>
+            <Item
+              key={random}
+              onClose={() => {
+                setRandom(random + 1);
+              }}
+            />
+          </Fragment>
+        );
+      })}
     </div>
   );
 }

--- a/packages/next-common/components/scrollPrompt/index.js
+++ b/packages/next-common/components/scrollPrompt/index.js
@@ -1,9 +1,8 @@
 import { SystemClose } from "@osn/icons/subsquare";
 import { cn } from "next-common/utils";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { animate, useAnimate } from "framer-motion";
+import { useAnimate } from "framer-motion";
 import { useWindowSize } from "react-use";
-import { Fragment } from "react";
 
 export const PromptTypes = {
   INFO: "info",
@@ -175,98 +174,6 @@ export function ScrollPromptItemWrapper({ prompt }) {
         role="button"
         onClick={prompt.close}
       />
-    </div>
-  );
-}
-
-export function AccountPanelScroll({ items }) {
-  const wrapperRef = useRef();
-  const { width } = useWindowSize();
-  const isMobile = width < 768;
-  const [total, setTotal] = useState(0);
-  const pauseRef = useRef(false);
-
-  const pageSize = total > 2 ? 2 : 1;
-
-  const wrapperHeight = useMemo(() => {
-    if (!total) {
-      return 0;
-    }
-    if (isMobile) {
-      return pageSize * MOBILE_ITEM_HEIGHT + ITEM_GAP * (pageSize - 1);
-    }
-    return pageSize * ITEM_HEIGHT + ITEM_GAP * (pageSize - 1);
-  }, [isMobile, pageSize, total]);
-
-  const [random, setRandom] = useState(1);
-  useEffect(() => {
-    setTotal(wrapperRef.current.children.length / 2);
-  }, [random]);
-
-  const marginTop = useMemo(() => {
-    if (isMobile) {
-      return (MOBILE_ITEM_HEIGHT + ITEM_GAP) * 1;
-    }
-    return (ITEM_HEIGHT + ITEM_GAP) * 1;
-  }, [isMobile]);
-
-  const indexRef = useRef(0);
-
-  useEffect(() => {
-    if (total < 2) {
-      return;
-    }
-
-    const interval = setInterval(() => {
-      if (pauseRef.current || !wrapperRef.current) {
-        return;
-      }
-      if (indexRef.current > total) {
-        wrapperRef.current?.scrollTo({
-          top: 0,
-        });
-        indexRef.current = 1;
-      }
-      const scrollTop = wrapperRef.current?.scrollTop;
-
-      animate(0, 100, {
-        duration: 1,
-        times: [0, 1],
-        onUpdate: (v) => {
-          wrapperRef.current?.scrollTo({
-            top: (v / 100) * marginTop + scrollTop,
-          });
-        },
-      });
-
-      indexRef.current++;
-    }, 6500);
-    return () => clearInterval(interval);
-  }, [marginTop, total]);
-
-  return (
-    <div
-      ref={wrapperRef}
-      style={{
-        height: wrapperHeight + "px",
-        display: total ? "" : "none",
-      }}
-      className=" overflow-y-hidden flex flex-col gap-1"
-      onMouseEnter={() => (pauseRef.current = true)}
-      onMouseLeave={() => (pauseRef.current = false)}
-    >
-      {[...items, ...items].map((Item, index) => {
-        return (
-          <Fragment key={index}>
-            <Item
-              key={random}
-              onClose={() => {
-                setRandom(random + 1);
-              }}
-            />
-          </Fragment>
-        );
-      })}
     </div>
   );
 }


### PR DESCRIPTION
- refactor account panel prompts
- prompt item  hook transform to component
- AssetHubManagePrompt only show on polkadot and kusama chain