### PR TITLE
Maintenance of IBP endpoints for several chains

### DIFF
--- a/packages/next-common/utils/consts/settings/ajuna.js
+++ b/packages/next-common/utils/consts/settings/ajuna.js
@@ -24,14 +24,6 @@ const nodes = [
     url: "wss://rpc-para.ajuna.network",
   },
   {
-    name: "IBP1",
-    url: "wss://ajuna.ibp.network",
-  },
-  {
-    name: "IBP2",
-    url: "wss://ajuna.dotters.network",
-  },
-  {
     name: "OnFinality",
     url: "wss://ajuna.api.onfinality.io/public-ws",
   },

--- a/packages/next-common/utils/consts/settings/bifrostPolkadot.js
+++ b/packages/next-common/utils/consts/settings/bifrostPolkadot.js
@@ -26,14 +26,6 @@ const DEFAULT_NODES = [
     name: "LiebiEU",
     url: "wss://eu.bifrost-polkadot-rpc.liebi.com/ws",
   },
-  {
-    name: "IBP1",
-    url: "wss://bifrost-polkadot.ibp.network",
-  },
-  {
-    name: "IBP2",
-    url: "wss://bifrost-polkadot.dotters.network",
-  },
 ];
 
 const links = bifrost.links;

--- a/packages/next-common/utils/consts/settings/collectives/endpoints.js
+++ b/packages/next-common/utils/consts/settings/collectives/endpoints.js
@@ -5,7 +5,11 @@ export const collectivesEndpoints = [
   },
   {
     name: "IBP1",
-    url: "wss://sys.ibp.network/collectives-polkadot",
+    url: "wss://collectives-polkadot.ibp.network",
+  },
+  {
+    name: "IBP2",
+    url: "wss://collectives-polkadot.dotters.network",
   },
   {
     name: "LuckyFriday",
@@ -16,16 +20,12 @@ export const collectivesEndpoints = [
     url: "wss://collectives.api.onfinality.io/public-ws",
   },
   {
-    name: "Dewllir",
+    name: "Dwellir",
     url: "wss://polkadot-collectives-rpc.dwellir.com",
   },
   {
-    name: "Dewllir Tunisia",
+    name: "Dwellir Tunisia",
     url: "wss://polkadot-collectives-rpc-tn.dwellir.com/",
-  },
-  {
-    name: "IBP2",
-    url: "wss://sys.dotters.network/collectives-polkadot",
   },
   {
     name: "RadiumBlock",

--- a/packages/next-common/utils/consts/settings/common/paseo.js
+++ b/packages/next-common/utils/consts/settings/common/paseo.js
@@ -60,7 +60,11 @@ export const paseoRelayChainNodes = [
   },
   {
     name: "IBP1",
-    url: "wss://rpc.ibp.network/paseo",
+    url: "wss://paseo.ibp.network",
+  },
+  {
+    name: "IBP2",
+    url: "wss://paseo.dotters.network",
   },
   {
     name: "StakeWorld",
@@ -70,16 +74,12 @@ export const paseoRelayChainNodes = [
     name: "Dwellir",
     url: "wss://paseo-rpc.n.dwellir.com",
   },
-  {
-    name: "IBP2",
-    url: "wss://paseo.dotters.network",
-  },
 ];
 
 export const paseoAssetHubNodes = [
   {
     name: "IBP1",
-    url: "wss://sys.ibp.network/asset-hub-paseo",
+    url: "wss://asset-hub-paseo.ibp.network",
   },
   {
     name: "IBP2",

--- a/packages/next-common/utils/consts/settings/hydradx.js
+++ b/packages/next-common/utils/consts/settings/hydradx.js
@@ -27,12 +27,12 @@ const endpoints = [
     url: "wss://hydration.ibp.network",
   },
   {
-    name: "Helikon",
-    url: "wss://rpc.helikon.io/hydradx",
-  },
-  {
     name: "IBP2",
     url: "wss://hydration.dotters.network",
+  },
+  {
+    name: "Helikon",
+    url: "wss://rpc.helikon.io/hydradx",
   },
   {
     name: "Dwellir",

--- a/packages/next-common/utils/consts/settings/hyperBridge.js
+++ b/packages/next-common/utils/consts/settings/hyperBridge.js
@@ -11,14 +11,6 @@ const ProjectIconHyperBridge = dynamic(() =>
 
 const endpoints = [
   {
-    name: "IBP1",
-    url: "wss://nexus.ibp.network",
-  },
-  {
-    name: "IBP2",
-    url: "wss://nexus.dotters.network",
-  },
-  {
     name: "BlockOps",
     url: "wss://hyperbridge-nexus-rpc.blockops.network",
   },

--- a/packages/next-common/utils/consts/settings/kusama/nodes.js
+++ b/packages/next-common/utils/consts/settings/kusama/nodes.js
@@ -5,7 +5,11 @@ const defaultKusamaNodes = [
   },
   {
     name: "IBP1",
-    url: "wss://rpc.ibp.network/kusama",
+    url: "wss://kusama.ibp.network",
+  },
+  {
+    name: "IBP2",
+    url: "wss://kusama.dotters.network",
   },
   {
     name: "Stakeworld",
@@ -30,10 +34,6 @@ const defaultKusamaNodes = [
   {
     name: "Dwellir Tunisia",
     url: "wss://kusama-rpc-tn.dwellir.com",
-  },
-  {
-    name: "IBP2",
-    url: "wss://kusama.dotters.network",
   },
   {
     name: "LuckyFriday",

--- a/packages/next-common/utils/consts/settings/kusamaAssetHub/endpoints.js
+++ b/packages/next-common/utils/consts/settings/kusamaAssetHub/endpoints.js
@@ -1,13 +1,13 @@
 const kusamaAssetHubNodes = [
   { name: "Parity", url: "wss://kusama-asset-hub-rpc.polkadot.io" },
-  { name: "IBP1", url: "wss://sys.ibp.network/asset-hub-kusama" },
+  { name: "IBP1", url: "wss://asset-hub-kusama.ibp.network" },
+  { name: "IBP2", url: "wss://asset-hub-kusama.dotters.network" },
   {
     name: "RadiumBlock",
     url: "wss://statemine.public.curie.radiumblock.co/ws",
   },
   { name: "Dwellir", url: "wss://asset-hub-kusama-rpc.n.dwellir.com" },
   { name: "Dwellir Tunisia", url: "wss://statemine-rpc-tn.dwellir.com" },
-  { name: "IBP2", url: "wss://asset-hub-kusama.dotters.network/" },
   { name: "LuckyFriday", url: "wss://rpc-asset-hub-kusama.luckyfriday.io" },
   { name: "Stakeworld", url: "wss://ksm-rpc.stakeworld.io/assethub" },
   {

--- a/packages/next-common/utils/consts/settings/kusamaCoretime/endpoints.js
+++ b/packages/next-common/utils/consts/settings/kusamaCoretime/endpoints.js
@@ -5,15 +5,15 @@ const kusamaCoretimeNodes = [
   },
   {
     name: "IBP1",
-    url: "wss://sys.ibp.network/coretime-kusama",
-  },
-  {
-    name: "Stakeworld",
-    url: "wss://ksm-rpc.stakeworld.io/coretime",
+    url: "wss://coretime-kusama.ibp.network",
   },
   {
     name: "IBP2",
     url: "wss://coretime-kusama.dotters.network",
+  },
+  {
+    name: "Stakeworld",
+    url: "wss://ksm-rpc.stakeworld.io/coretime",
   },
   {
     name: "LuckyFriday",

--- a/packages/next-common/utils/consts/settings/kusamaPeople/index.js
+++ b/packages/next-common/utils/consts/settings/kusamaPeople/index.js
@@ -21,15 +21,15 @@ const kusamaPeople = {
     },
     {
       name: "IBP1",
-      url: "wss://sys.ibp.network/people-kusama",
-    },
-    {
-      name: "OnFinality",
-      url: "wss://people-kusama.api.onfinality.io/public-ws",
+      url: "wss://people-kusama.ibp.network",
     },
     {
       name: "IBP2",
       url: "wss://people-kusama.dotters.network",
+    },
+    {
+      name: "OnFinality",
+      url: "wss://people-kusama.api.onfinality.io/public-ws",
     },
     {
       name: "Dwellir",

--- a/packages/next-common/utils/consts/settings/paseoPeople.js
+++ b/packages/next-common/utils/consts/settings/paseoPeople.js
@@ -21,7 +21,7 @@ const paseoPeople = {
     },
     {
       name: "IBP1",
-      url: "wss://sys.ibp.network/people-paseo",
+      url: "wss://people-paseo.ibp.network",
     },
     {
       name: "IBP2",

--- a/packages/next-common/utils/consts/settings/polkadot/nodes.js
+++ b/packages/next-common/utils/consts/settings/polkadot/nodes.js
@@ -5,7 +5,7 @@ const defaultPolkadotNodes = [
   },
   {
     name: "IBP1",
-    url: "wss://rpc.ibp.network/polkadot",
+    url: "wss://polkadot.ibp.network",
   },
   {
     name: "IBP2",

--- a/packages/next-common/utils/consts/settings/polkadotAssetHub/endpoints.js
+++ b/packages/next-common/utils/consts/settings/polkadotAssetHub/endpoints.js
@@ -5,7 +5,7 @@ const polkadotAssetHubNodes = [
   },
   {
     name: "IBP1",
-    url: "wss://sys.ibp.network/asset-hub-polkadot",
+    url: "wss://asset-hub-polkadot.ibp.network",
   },
   {
     name: "IBP2",

--- a/packages/next-common/utils/consts/settings/polkadotCoretime/index.js
+++ b/packages/next-common/utils/consts/settings/polkadotCoretime/index.js
@@ -21,7 +21,7 @@ const polkadotCoretime = {
     },
     {
       name: "IBP1",
-      url: "wss://sys.ibp.network/coretime-polkadot",
+      url: "wss://coretime-polkadot.ibp.network",
     },
     {
       name: "IBP2",

--- a/packages/next-common/utils/consts/settings/polkadotPeople/index.js
+++ b/packages/next-common/utils/consts/settings/polkadotPeople/index.js
@@ -21,15 +21,15 @@ const polkadotPeople = {
     },
     {
       name: "IBP1",
-      url: "wss://sys.ibp.network/people-polkadot",
-    },
-    {
-      name: "OnFinality",
-      url: "wss://people-polkadot.api.onfinality.io/public-ws",
+      url: "wss://people-polkadot.ibp.network",
     },
     {
       name: "IBP2",
       url: "wss://people-polkadot.dotters.network",
+    },
+    {
+      name: "OnFinality",
+      url: "wss://people-polkadot.api.onfinality.io/public-ws",
     },
     {
       name: "LuckyFriday",

--- a/packages/next-common/utils/consts/settings/westendCollectives.js
+++ b/packages/next-common/utils/consts/settings/westendCollectives.js
@@ -24,20 +24,12 @@ const westendCollectivesEndpoints = [
     url: "wss://westend-collectives-rpc.polkadot.io/",
   },
   {
-    name: "IBP1",
-    url: "wss://sys.ibp.network/collectives-westend",
-  },
-  {
     name: "Dwellir",
     url: "wss://collectives-westend-rpc.dwellir.com",
   },
   {
     name: "Dwellir Tunisia",
     url: "wss://westend-collectives-rpc-tn.dwellir.com",
-  },
-  {
-    name: "IBP2",
-    url: "wss://sys.dotters.network/collectives-westend",
   },
 ];
 

--- a/packages/next-common/utils/consts/settingsPolyfill/kusamaBridge.js
+++ b/packages/next-common/utils/consts/settingsPolyfill/kusamaBridge.js
@@ -15,7 +15,7 @@ export default {
     },
     {
       name: "IBP1",
-      url: "wss://sys.ibp.network/bridgehub-kusama",
+      url: "wss://bridge-hub-kusama.ibp.network",
     },
     {
       name: "IBP2",

--- a/packages/next-common/utils/consts/settingsPolyfill/polkadotBridge.js
+++ b/packages/next-common/utils/consts/settingsPolyfill/polkadotBridge.js
@@ -15,7 +15,7 @@ export default {
     },
     {
       name: "IBP1",
-      url: "wss://sys.ibp.network/bridgehub-polkadot",
+      url: "wss://bridge-hub-polkadot.ibp.network",
     },
     {
       name: "IBP2",


### PR DESCRIPTION
Dear team, hello!

Please kindly consider this Pull Request to update the RPC endpoints provided by the Infrastructure Builders Programme (IBP).

The changes are, in general terms:

- Reflecting the subdomain routing for `ibp.network`, which is more reliable than the prior alternative of path routing (e.g. `rpc.ibp.network/polkadot` now becomes `polkadot.ibp.network`).
- Removing chains that are no longer supported by the IBP: e.g. `ajuna`, `bifrost`, `hyperbridge`, etc.

Many thanks in advance!

Best regards

**_Milos_**