### PR TITLE
fix: handle missing child bounties gracefully (#7283)

### DIFF
--- a/packages/next-common/components/pages/components/bounty/childBountiesTable.js
+++ b/packages/next-common/components/pages/components/bounty/childBountiesTable.js
@@ -15,7 +15,21 @@ export default function ChildBountiesTable({ childBounties }) {
     return null;
   }
 
-  const listData = childBounties.items.map((bounty) => {
+  // Filter out items with missing or invalid data (missing index or parentBountyId)
+  const validItems = childBounties.items.filter(
+    (bounty) =>
+      bounty &&
+      typeof bounty.index !== "undefined" &&
+      bounty.index !== null &&
+      typeof bounty.parentBountyId !== "undefined" &&
+      bounty.parentBountyId !== null,
+  );
+
+  if (!validItems.length) {
+    return null;
+  }
+
+  const listData = validItems.map((bounty) => {
     return [
       <div
         key={bounty.index}
@@ -56,10 +70,10 @@ export default function ChildBountiesTable({ childBounties }) {
     <div>
       <KvList data={listData} />
 
-      {childBounties.total > 5 && (
+      {childBounties.total > 5 && validItems[0]?.parentBountyId && (
         <div className="mt-4 text-right">
           <Link
-            href={`/treasury/child-bounties?parentBountyId=${childBounties.items[0].parentBountyId}`}
+            href={`/treasury/child-bounties?parentBountyId=${validItems[0].parentBountyId}`}
             className="text14Medium text-theme500"
           >
             View all


### PR DESCRIPTION
## Summary

Filter out null/invalid child bounty items before rendering to prevent crashes when some child bounty entries have missing \index\ or \parentBountyId\ properties.

## Changes

- Added validation filter in \ChildBountiesTable\ to skip items where \ounty\ is null/undefined, or \index\/\parentBountyId\ are missing
- Added safe check on \alidItems[0]?.parentBountyId\ before rendering the 'View all' link

## Testing

The fix handles the cases described in #7283 where parent bounties (e.g., #11, #17, #43, #38) have child bounty ID ranges that may contain entries with missing data.

---

**Bounty:** #7283