### PR TITLE
fix: Show secretary salary cycle on top of the collectives overview page, #7344

### DIFF
--- a/packages/next-common/components/overview/fellowship/finance/currentSalaryCycle/index.jsx
+++ b/packages/next-common/components/overview/fellowship/finance/currentSalaryCycle/index.jsx
@@ -5,15 +5,16 @@ import Link from "next-common/components/link";
 import FellowshipSalaryStatsDetailLink from "next-common/components/overview/fellowship/salary/detailLink";
 import SalaryCycleStatus from "./status";
 import Loading from "next-common/components/loading";
+import { useCollectivesSection } from "next-common/context/collectives/collectives";
 
-function CurrentSalaryCycle({ cycleIndex }) {
+function CurrentSalaryCycle({ title = "Current Salary Cycle", cycleIndex }) {
   return (
     <div className="text12Medium text-textTertiary space-x-1">
       <FellowshipSalaryStatsDetailLink
         index={cycleIndex}
         className="text12Medium text-textTertiary hover:underline"
       >
-        Current Salary Cycle
+        {title}
       </FellowshipSalaryStatsDetailLink>
       <span>·</span>
       <span>#{cycleIndex}</span>
@@ -39,9 +40,11 @@ export function FellowshipCurrentSalaryCycleLoading() {
   );
 }
 
-export function FellowshipCurrentSalaryCycle({ cycleIndex, children }) {
+export function FellowshipCurrentSalaryCycle({ title, cycleIndex, children }) {
   return (
-    <SummaryItem title={<CurrentSalaryCycle cycleIndex={cycleIndex} />}>
+    <SummaryItem
+      title={<CurrentSalaryCycle title={title} cycleIndex={cycleIndex} />}
+    >
       <div className="flex flex-col gap-1">
         <SalaryCycleStatus />
         {children}
@@ -50,7 +53,8 @@ export function FellowshipCurrentSalaryCycle({ cycleIndex, children }) {
   );
 }
 
-export default function FellowshipCurrentSalaryCycleSummary() {
+export default function FellowshipCurrentSalaryCycleSummary({ title }) {
+  const section = useCollectivesSection();
   const fellowshipSalaryStats = useFellowshipSalaryStats();
 
   if (
@@ -63,7 +67,7 @@ export default function FellowshipCurrentSalaryCycleSummary() {
   const { cycleIndex } = fellowshipSalaryStats;
 
   return (
-    <FellowshipCurrentSalaryCycle cycleIndex={cycleIndex}>
+    <FellowshipCurrentSalaryCycle title={title} cycleIndex={cycleIndex}>
       <div className="flex space-x-2">
         <FellowshipSalaryStatsDetailLink
           index={cycleIndex}
@@ -71,7 +75,10 @@ export default function FellowshipCurrentSalaryCycleSummary() {
         >
           View Detail
         </FellowshipSalaryStatsDetailLink>
-        <Link href="/fellowship/salary" className="text12Medium text-theme500">
+        <Link
+          href={`/${section}/salary`}
+          className="text12Medium text-theme500"
+        >
           All Cycles
         </Link>
       </div>

--- a/packages/next-common/components/overview/fellowship/finance/index.jsx
+++ b/packages/next-common/components/overview/fellowship/finance/index.jsx
@@ -24,10 +24,10 @@ export default function FellowshipFinanceOverview() {
         <FellowshipTreasury />
         <FellowshipSalary />
         <CollectivesProvider>
-          <FellowshipCurrentSalaryCycleSummary title="Current Fellowship Salary Cycle" />
+          <FellowshipCurrentSalaryCycleSummary title="Fellowship Salary Cycle" />
         </CollectivesProvider>
         <CollectivesProvider section="secretary">
-          <FellowshipCurrentSalaryCycleSummary title="Current Secretary Salary Cycle" />
+          <FellowshipCurrentSalaryCycleSummary title="Secretary Salary Cycle" />
         </CollectivesProvider>
       </SecondaryCard>
     </>

--- a/packages/next-common/components/overview/fellowship/finance/index.jsx
+++ b/packages/next-common/components/overview/fellowship/finance/index.jsx
@@ -10,7 +10,7 @@ import { useNavCollapsed } from "next-common/context/nav";
 export default function FellowshipFinanceOverview() {
   const [navCollapsed] = useNavCollapsed();
   return (
-    <CollectivesProvider>
+    <>
       <TitleContainer className="mb-4">Fellowship Finance</TitleContainer>
 
       <SecondaryCard
@@ -23,8 +23,13 @@ export default function FellowshipFinanceOverview() {
       >
         <FellowshipTreasury />
         <FellowshipSalary />
-        <FellowshipCurrentSalaryCycleSummary />
+        <CollectivesProvider>
+          <FellowshipCurrentSalaryCycleSummary title="Current Fellowship Salary Cycle" />
+        </CollectivesProvider>
+        <CollectivesProvider section="secretary">
+          <FellowshipCurrentSalaryCycleSummary title="Current Secretary Salary Cycle" />
+        </CollectivesProvider>
       </SecondaryCard>
-    </CollectivesProvider>
+    </>
   );
 }

--- a/packages/next-common/components/summary/allianceOverviewSummary/index.js
+++ b/packages/next-common/components/summary/allianceOverviewSummary/index.js
@@ -49,6 +49,9 @@ export default function AllianceOverviewSummary() {
       <CollectivesProvider>
         <FellowshipCurrentSalaryCycleSummary />
       </CollectivesProvider>
+      <CollectivesProvider section="secretary">
+        <FellowshipCurrentSalaryCycleSummary />
+      </CollectivesProvider>
     </SummaryLayout>
   );
 }


### PR DESCRIPTION
refs #7344